### PR TITLE
Support for Comgate error codes

### DIFF
--- a/src/Exception/ErrorCodeException.php
+++ b/src/Exception/ErrorCodeException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Comgate\Exception;
+
+class ErrorCodeException extends \Exception
+{
+
+}

--- a/src/Response/CreatePaymentResponse.php
+++ b/src/Response/CreatePaymentResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Comgate\Response;
 
 use Comgate\Enum\ResponseCode;
+use Comgate\Exception\ErrorCodeException;
 use Comgate\Exception\InvalidArgumentException;
 
 class CreatePaymentResponse
@@ -32,6 +33,7 @@ class CreatePaymentResponse
     /**
      * @param array $rawData
      * @throws InvalidArgumentException
+     * @throws ErrorCodeException
      */
     public function __construct(array $rawData)
     {
@@ -45,6 +47,10 @@ class CreatePaymentResponse
             $this->message = $rawData['message'];
         } else {
             throw new InvalidArgumentException('Missing "message" in response');
+        }
+
+        if (!$this->isOk()) {
+            throw new ErrorCodeException($this->message, $this->code);
         }
 
         if (isset($rawData['transId'])) {

--- a/test/CreatePaymentResponseTest.php
+++ b/test/CreatePaymentResponseTest.php
@@ -3,6 +3,7 @@
 namespace ComgateTest;
 
 use Comgate\Enum\ResponseCode;
+use Comgate\Exception\ErrorCodeException;
 use Comgate\Exception\InvalidArgumentException;
 use Comgate\Response\CreatePaymentResponse;
 use PHPUnit\Framework\TestCase;
@@ -98,6 +99,9 @@ class CreatePaymentResponseTest extends TestCase
 
     public function testIsNotOk()
     {
+        $this->expectException(ErrorCodeException::class);
+        $this->expectExceptionCode(ResponseCode::CODE_CHOOSE_CORRECT_METHOD);
+
         $response = new CreatePaymentResponse(
             [
                 'code'     => ResponseCode::CODE_CHOOSE_CORRECT_METHOD,
@@ -106,15 +110,13 @@ class CreatePaymentResponseTest extends TestCase
                 'redirect' => 'http://test.cz',
             ]
         );
-
-        $this->assertSame(false, $response->isOk());
     }
 
     public function testGetMessage()
     {
         $response = new CreatePaymentResponse(
             [
-                'code'     => ResponseCode::CODE_CHOOSE_CORRECT_METHOD,
+                'code'     => ResponseCode::CODE_OK,
                 'message'  => 'OK',
                 'transId'  => 'asd-asd-asd-asd',
                 'redirect' => 'http://test.cz',
@@ -128,7 +130,7 @@ class CreatePaymentResponseTest extends TestCase
     {
         $response = new CreatePaymentResponse(
             [
-                'code'     => ResponseCode::CODE_CHOOSE_CORRECT_METHOD,
+                'code'     => ResponseCode::CODE_OK,
                 'message'  => 'OK',
                 'transId'  => 'asd-asd-asd-asd',
                 'redirect' => 'http://test.cz',
@@ -142,7 +144,7 @@ class CreatePaymentResponseTest extends TestCase
     {
         $response = new CreatePaymentResponse(
             [
-                'code'     => ResponseCode::CODE_CHOOSE_CORRECT_METHOD,
+                'code'     => ResponseCode::CODE_OK,
                 'message'  => 'OK',
                 'transId'  => 'asd-asd-asd-asd',
                 'redirect' => 'http://test.cz',


### PR DESCRIPTION
Hi.
Support for Comgate error codes is missing. When a non-0 code is returned when creating a payment, InvalidArgumentException ('Missing' transId 'in response') is throw. Instead, I suggest informing about the error that occurred.